### PR TITLE
Package checkseum.0.3.4+android

### DIFF
--- a/packages/checkseum/checkseum.0.3.4+android/opam
+++ b/packages/checkseum/checkseum.0.3.4+android/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/checkseum"
+bug-reports:  "https://github.com/mirage/checkseum/issues"
+dev-repo:     "git+https://github.com/mirage/checkseum.git"
+doc:          "https://mirage.github.io/checkseum/"
+license:      "MIT"
+synopsis:     "Adler-32, CRC32 and CRC32-C implementation in C and OCaml"
+description: """
+Checkseum is a library to provide implementation of Adler-32, CRC32 and CRC32-C
+in C and OCaml.
+
+This library use the linking trick to choose between the C implementation
+(checkseum.c) or the OCaml implementation (checkseum.ocaml). This library is on
+top of optint to get the best representation of an int32. """
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "ocaml" "./install/install.ml" ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+install: [
+  [ "dune" "install" "-p" name ] {with-test}
+  [ "ocaml" "./test/test_runes.ml" ] {with-test}
+]
+
+depends: [
+  "ocaml"         {>= "4.07.0"}
+  "dune"          {>= "2.6.0"}
+  "conf-pkg-config" {build}
+  "dune-configurator"
+  "optint"        {>= "0.2.0"}
+  "alcotest"      {with-test}
+  "bos"           {with-test}
+  "astring"       {with-test}
+  "fmt"           {with-test}
+  "fpath"         {with-test}
+  "rresult"       {with-test}
+  "ocamlfind"     {with-test}
+]
+
+depopts: [
+  "ocaml-freestanding"
+]
+
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding" {< "0.4.3"}
+]
+url {
+  src:
+    "https://github.com/jonahbeckford/checkseum/archive/v0.3.4+android.tar.gz"
+  checksum: [
+    "md5=6cdf55fbd475f593e10b46081dd8ee19"
+    "sha512=83690cdab0694aa6eee2bee7cfcd747c17951086242dd7e714f2a8fb6bb9c43e254a923634b164133bbf48b01d8b2965f66b9c15129c68125b2b9f986479b67d"
+  ]
+}


### PR DESCRIPTION
### `checkseum.0.3.4+android`
Adler-32, CRC32 and CRC32-C implementation in C and OCaml
Checkseum is a library to provide implementation of Adler-32, CRC32 and CRC32-C
in C and OCaml.

This library use the linking trick to choose between the C implementation
(checkseum.c) or the OCaml implementation (checkseum.ocaml). This library is on
top of optint to get the best representation of an int32.



---
* Homepage: https://github.com/mirage/checkseum
* Source repo: git+https://github.com/mirage/checkseum.git
* Bug tracker: https://github.com/mirage/checkseum/issues

---
:camel: Pull-request generated by opam-publish v2.1.0