### PR TITLE
2 packages from diskuv/dkml-runtime-common at 1.0.2~prerel26

### DIFF
--- a/packages/dkml-runtime-common-native/dkml-runtime-common-native.1.0.2~prerel26/opam
+++ b/packages/dkml-runtime-common-native/dkml-runtime-common-native.1.0.2~prerel26/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Common runtime code used in DKML"
+description: "Common runtime code used in DKML.
+
+This package has no dependencies and is what you should include
+in dependencies of custom OCaml compilers.
+
+The runtime code will be available in the 'lib/dkml-runtime-common-native' folder
+of your Opam switch or findlib installation.
+
+If you use opam-monorepo you should install dkml-runtime-common instead."
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-runtime-common"
+bug-reports: "https://github.com/diskuv/dkml-runtime-common/issues"
+dev-repo: "git+https://github.com/diskuv/dkml-runtime-common.git"
+install: [
+  [".\\install.cmd" "%{_:lib}%"] {  os = "win32"}
+  ["./install.sh"   "%{_:lib}%"] {!(os = "win32")}
+]
+url {
+  src:
+    "https://github.com/diskuv/dkml-runtime-common/archive/1.0.2-prerel26.tar.gz"
+  checksum: [
+    "md5=40e99120932cd21d7ba727df676ba364"
+    "sha512=6c81f117913d0bafcc7cff92922247b5f2713e73fdbb2e39ec1e5fceea902cfe1af04019df8eba4b02599146131f98fa7dffe9bb7ef31931b14fcec39ba55fb8"
+  ]
+}

--- a/packages/dkml-runtime-common/dkml-runtime-common.1.0.2~prerel26/opam
+++ b/packages/dkml-runtime-common/dkml-runtime-common.1.0.2~prerel26/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "Common runtime code used in DKML"
+description: "Common runtime code used in DKML.
+
+The runtime code will be available in the 'lib/dkml-runtime-common' folder
+of your Opam switch or findlib installation."
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-runtime-common"
+bug-reports: "https://github.com/diskuv/dkml-runtime-common/issues"
+dev-repo: "git+https://github.com/diskuv/dkml-runtime-common.git"
+depends: [
+  "dune"
+]
+build: [
+  ["dune" "build" "-p" name]
+]
+url {
+  src:
+    "https://github.com/diskuv/dkml-runtime-common/archive/1.0.2-prerel26.tar.gz"
+  checksum: [
+    "md5=40e99120932cd21d7ba727df676ba364"
+    "sha512=6c81f117913d0bafcc7cff92922247b5f2713e73fdbb2e39ec1e5fceea902cfe1af04019df8eba4b02599146131f98fa7dffe9bb7ef31931b14fcec39ba55fb8"
+  ]
+}


### PR DESCRIPTION
Common runtime code used in DKML

This pull-request concerns:
-`dkml-runtime-common.1.0.2~prerel26`
-`dkml-runtime-common-native.1.0.2~prerel26`



---
* Homepage: https://github.com/diskuv/dkml-runtime-common
* Source repo: git+https://github.com/diskuv/dkml-runtime-common.git
* Bug tracker: https://github.com/diskuv/dkml-runtime-common/issues

---
:camel: Pull-request generated by opam-publish v2.1.0