### PR TITLE
2 packages from diskuv/dkml-compiler

### DIFF
--- a/packages/dkml-base-compiler/dkml-base-compiler.4.12.1~v1.0.2~prerel27/opam
+++ b/packages/dkml-base-compiler/dkml-base-compiler.4.12.1~v1.0.2~prerel27/opam
@@ -1,0 +1,143 @@
+opam-version: "2.0"
+synopsis: "OCaml cross-compiler and libraries from the DKML distribution that works with at least Win32 and macOS"
+description:
+  """The DKML distribution of the OCaml bytecode and native compiler, Stdlib and the other OCaml libraries (str, unix, bigarray, etc.).
+A cross-compiler for macOS x86_64 to macOS arm64 is included; for build consistency the regular OCaml compiler will be for x86_64 regardless of whether the build machine is Apple Silicon.
+Install with something like: opam switch create dkml-4.12.1 '--formula="dkml-base-compiler" {>= "4.12.1~" & < "4.13.0~"}'"""
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-compiler"
+bug-reports: "https://github.com/diskuv/dkml-compiler/issues"
+depends: [
+  "ocaml" {= "4.12.1" & post}
+
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+
+  "dkml-runtime-common-native" {= "1.0.2~prerel27"}
+]
+depopts: [
+  "ocaml-option-32bit"
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]
+available: [
+  opam-version >= "2.1.0" &
+  ( (arch = "x86_64" & (os = "linux" | os = "win32" | os = "macos")) |
+    (arch = "x86_32" & (os = "linux" | os = "win32")) |
+    (arch = "arm64" & os = "macos") )
+]
+build: [
+  # Dump Homebrew, which is needed for reproducible build auditing in drc's crossplatform-functions.sh.
+  ["sh" "scripts/macos-bundle-dump.sh"] {os = "macos"}
+
+  # OCaml source code
+  ["install" "-d" "dl/ocaml/flexdll"]
+  ["tar" "xCfz" "dl/ocaml"          "dl/ocaml.tar.gz"   "--strip-components=1"]
+  ["tar" "xCfz" "dl/ocaml/flexdll"  "dl/flexdll.tar.gz" "--strip-components=1"]
+
+  # Create a DKMLDIR. Its structure mimics a git submodule setup.
+  #   <dkmldir>/.dkmlroot
+  ["install" "-d" "dkmldir"]
+  #     4.12.1~v0.4.1          --dkml-semver--> 0.4.1
+  #     4.12.1~v0.4.1~prerel69 --dkml-semver--> 0.4.1-prerel69
+  ["sh" "-eufc" "printf 'dkml_root_version=%s\\n' '%{version}%' | sed 's/[0-9.]*~v//; s/~/-/' > dkmldir/.dkmlroot"]
+
+  #   <dkmldir>/vendor/drc/
+  ["install" "-d" "dkmldir/vendor/drc"]
+  #     tar through pipe is essentially an rsync (without requiring rsync)
+  ["sh" "-eufc" "tar cCf '%{dkml-runtime-common-native:lib}%/' - . | tar xCf dkmldir/vendor/drc/ -"]
+
+  #   <dkmldir>/vendor/dkml-compiler/
+  ["install" "-d" "dkmldir/vendor/dkml-compiler/src" "dkmldir/vendor/dkml-compiler/env"]
+  #     only the standard compiler environment is needed for the base compiler
+  ["install" "env/standard-compiler-env-to-ocaml-configure-env.sh"      "dkmldir/vendor/dkml-compiler/env/"]
+  #     tar through pipe is essentially an rsync (without requiring rsync)
+  ["sh" "-eufc" "tar cCf src/ - . | tar xCf dkmldir/vendor/dkml-compiler/src/ -"]
+]
+install: [
+  # Run r-c-ocaml-1-setup.sh
+  [
+    "env" "TOPDIR=dkmldir/vendor/drc/all/emptytop"
+      "DKML_REPRODUCIBLE_SYSTEM_BREWFILE=%{_:build}%/Brewfile"
+      "dkmldir/vendor/dkml-compiler/src/r-c-ocaml-1-setup.sh"
+      "-d" "dkmldir"
+      "-t" "%{prefix}%"
+      "-f" "src-ocaml"
+      "-g" "%{_:share}%/mlcross"
+      "-v" "dl/ocaml"
+      "-z"
+      #   Host architectures
+      "-ewindows_x86"     { os = "win32" & (arch = "x86_32" |  ocaml-option-32bit:installed) }
+      "-ewindows_x86_64"  { os = "win32" & (arch = "x86_64" & !ocaml-option-32bit:installed) }      
+      "-elinux_x86"       { os = "linux" & (arch = "x86_32" |  ocaml-option-32bit:installed) }
+      "-elinux_x86_64"    { os = "linux" & (arch = "x86_64" & !ocaml-option-32bit:installed) }
+      "-edarwin_x86_64"   { os = "macos" & arch = "x86_64" }
+      "-edarwin_arm64"    { os = "macos" & arch = "arm64" }
+      #   Target architectures (if cross-compiling; similar to dkml-component-staging-ocamlrun.opam)
+      #     TODO: With the -adarwin_x86_64 configuration below, an Apple Silicon machine will produce an arm64 ocamlopt.opt
+      #     in the staging-files/darwin_arm64 directory,
+      #     and that ocamlopt.opt will create x86_64 OCaml native executables. So that darwin_arm64/bin/ocamlopt.opt will not
+      #     run on an x86_64 machine.
+      #     The -adarwin_arm64 configuration is similar but has one important difference. The config will produce an x86_64
+      #     ocamlopt.opt, in the staging-files/darwin_x86_64 directory, and that ocamlopt.opt will create arm64 OCaml native
+      #     executables. But that darwin_x86_64/bin/ocamlopt.opt _will_ run on almost _all_ Apple Silicon (arm64) machines
+      #     because of Rosetta2. The only major exception is Opam CI has disabled Rosetta2 as of Nov 8, 2022.
+      #     Ideally we would have [-aHOST] and [-aHOST-TARGET]. That is: -adarwin_x86_64, -adarwin_arm64 and
+      #     -adarwin_x86_64-darwin_arm64. But that cross specification has ripple effects that needs time (technical debt) to
+      #     get right. Luckily our build machines are always Apple x86_64 (GitHub Actions and GitLab CI/CD), and even if the
+      #     build machines were Apple Silicon we typically only care about the generated artifacts (the target ABI).
+      "-adarwin_x86_64=vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh" { os = "macos" & arch = "arm64" }
+      "-adarwin_arm64=vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh"  { os = "macos" & arch = "x86_64" }
+      #     TODO: Would be nice to bundle the 3 Android cross-compilers here since they are already supported
+      #     by DKML, but I (jonahbeckford@) doubt there is an Android NDK available on the Opam hosts.
+      #     Confer: https://github.com/diskuv/diskuv-ocaml-ghmirror/runs/4831077050
+      #     Perhaps the Android NDK should just be downloaded via an 'android-option-ndk23' package? That would give control of the NDK version.
+      # "-aandroid_arm64v8a=vendor/dkml-compiler/env/github-actions-ci-to-ocaml-configure-env.sh;android_x86_64=vendor/dkml-compiler/env/github-actions-ci-to-ocaml-configure-env.sh"] { os = "linux" & !ocaml-option-32bit:installed }
+      # "-aandroid_arm32v7a=vendor/dkml-compiler/env/github-actions-ci-to-ocaml-configure-env.sh" { os = "linux" & ocaml-option-32bit:installed }
+      "-k" "vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh"
+  ]
+
+  # Run r-c-ocaml-2-build_host-noargs.sh
+  [
+    "sh" "-eufc"
+    """
+    cd '%{prefix}%'
+    share/dkml/repro/100co/vendor/dkml-compiler/src/r-c-ocaml-2-build_host-noargs.sh
+    """
+  ]
+
+  # Run r-c-ocaml-3-build_cross-noargs.sh (typically a no-op unless we are cross-compiling)
+  [
+    "sh" "-eufc"
+    """
+    cd '%{prefix}%'
+    share/dkml/repro/100co/vendor/dkml-compiler/src/r-c-ocaml-3-build_cross-noargs.sh
+    """
+  ]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-compiler.git"
+extra-source "dl/ocaml.tar.gz" {
+  src: "https://github.com/ocaml/ocaml/archive/4.12.1.tar.gz"
+  checksum: "sha256=f5a48a90557cb47ace7b1590fcab1362a1af38629a218350f69c225c57e96a41"
+}
+extra-source "dl/flexdll.tar.gz" {
+  src: "https://github.com/alainfrisch/flexdll/archive/0.39.tar.gz"
+  checksum: "sha256=51a6ef2e67ff475c33a76b3dc86401a0f286c9a3339ee8145053ea02d2fb5974"
+}
+extra-source "dl/homebrew-bundle.tar.gz" {
+  src: "https://github.com/Homebrew/homebrew-bundle/archive/4756e4c4cf95485c5ea4da27375946c1dac2c71d.tar.gz"
+  checksum: [
+    "sha256=10c024ca7871cea36b4c27b2601971d3fa6cba6f37855613baf0026d0f555e76"
+  ]
+}
+url {
+  src:
+    "https://github.com/diskuv/dkml-compiler/archive/1.0.2-prerel27.tar.gz"
+  checksum: [
+    "md5=66e715d4f830cb23e4593a45b0a0adb4"
+    "sha512=fccc1c275b356c832c3e3dc73c6c69a609026f32ef903554f11627033d809b53b4180bade6c6afd248dcb8c0907a99a73750e6ed7d3fd53bc13155f774930a85"
+  ]
+}

--- a/packages/dkml-compiler-env/dkml-compiler-env.1.0.2~prerel27/opam
+++ b/packages/dkml-compiler-env/dkml-compiler-env.1.0.2~prerel27/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+synopsis: "Scripts to configure DKML compilation in various environments"
+description: "Scripts to configure DKML compilation in various environments"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-compiler"
+bug-reports: "https://github.com/diskuv/dkml-compiler/issues"
+dev-repo: "git+https://github.com/diskuv/dkml-compiler.git"
+install: [
+  [".\\install-env.cmd"  "%{_:lib}%"] {os = "win32"}
+  ["./install-env.sh" "%{_:lib}%"]  {!(os = "win32")}
+]
+url {
+  src:
+    "https://github.com/diskuv/dkml-compiler/archive/1.0.2-prerel27.tar.gz"
+  checksum: [
+    "md5=66e715d4f830cb23e4593a45b0a0adb4"
+    "sha512=fccc1c275b356c832c3e3dc73c6c69a609026f32ef903554f11627033d809b53b4180bade6c6afd248dcb8c0907a99a73750e6ed7d3fd53bc13155f774930a85"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`dkml-base-compiler.4.12.1~v1.0.2~prerel27`: OCaml cross-compiler and libraries from the DKML distribution that works with at least Win32 and
 macOS
-`dkml-compiler-env.1.0.2~prerel27`: Scripts to configure DKML compilation in various environments



---
* Homepage: https://github.com/diskuv/dkml-compiler
* Source repo: git+https://github.com/diskuv/dkml-compiler.git
* Bug tracker: https://github.com/diskuv/dkml-compiler/issues

---
:camel: Pull-request generated by opam-publish v2.1.0