### PR TITLE
Package ppx_expect.v0.15.1

### DIFF
--- a/packages/ppx_expect/ppx_expect.v0.15.1/opam
+++ b/packages/ppx_expect/ppx_expect.v0.15.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_expect"
+bug-reports: "https://github.com/janestreet/ppx_expect/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_expect.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_expect/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"           {>= "4.08.0"}
+  "base"            {>= "v0.15" & < "v0.16"}
+  "ppx_here"        {>= "v0.15" & < "v0.16"}
+  "ppx_inline_test" {>= "v0.15" & < "v0.16"}
+  "stdio"           {>= "v0.15" & < "v0.16"}
+  "dune"            {>= "2.0.0"}
+  "ppxlib"          {>= "0.23.0"}
+  "re"              {>= "1.8.0"}
+]
+synopsis: "Cram like framework for OCaml"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/jonahbeckford/ppx_expect/archive/v0.15.1+msvc.tar.gz"
+  checksum: [
+    "md5=745d42329878519f552b54c17ef987eb"
+    "sha512=5661c494f61b9abfaf104c154d8ab5c5d5f64bbcbfff55db87c8a457940f448fea8076aeac4612893d7030e67c917e276fc8b38007f74eefa584e44dfb034a36"
+  ]
+}


### PR DESCRIPTION
### `ppx_expect.v0.15.1`
Cram like framework for OCaml
Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppx_expect
* Source repo: git+https://github.com/janestreet/ppx_expect.git
* Bug tracker: https://github.com/janestreet/ppx_expect/issues

---
:camel: Pull-request generated by opam-publish v2.1.0