### PR TITLE
2 packages from diskuv/dkml-runtime-common at 2.1.0

### DIFF
--- a/packages/dkml-runtime-common-native/dkml-runtime-common-native.2.1.0/opam
+++ b/packages/dkml-runtime-common-native/dkml-runtime-common-native.2.1.0/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 synopsis: "Common runtime code used in DKML"
-description: "Common runtime code used in DKML.
+description: """\
+Common runtime code used in DKML.
 
 This package has no dependencies and is what you should include
 in dependencies of custom OCaml compilers.
@@ -8,29 +9,20 @@ in dependencies of custom OCaml compilers.
 The runtime code will be available in the 'lib/dkml-runtime-common-native' folder
 of your Opam switch or findlib installation.
 
-If you use opam-monorepo you should install dkml-runtime-common instead."
-maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
-authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+If you use opam-monorepo you should install dkml-runtime-common instead."""
+maintainer: "opensource+diskuv-ocaml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"
 license: "Apache-2.0"
 homepage: "https://github.com/diskuv/dkml-runtime-common"
 bug-reports: "https://github.com/diskuv/dkml-runtime-common/issues"
+build: ["sh" "tests/crossplatform-tests.sh"] {with-test & !(os = "win32")}
+install: ["sh" "./install.sh" "%{_:lib}%"]
 dev-repo: "git+https://github.com/diskuv/dkml-runtime-common.git"
-#   Must not rely on OCaml (ex. diskuvbox or dune) because this
-#   package is a dependency of OCaml compilers like dkml-base-compiler!
-depends: []
-build: [
-  ["sh" "tests/crossplatform-tests.sh"] { with-test & !(os = "win32") }
-]
-install: [
-  # TODO: opam does not pass to Command Prompt correctly when there is a
-  # space in the _:lib so we have to avoid the (correct) Command Prompt
-  # shell. https://github.com/ocaml/opam/issues/5673
-  #[".\\install.cmd" "\"%{_:lib}%\""] { os = "win32"}
-  ["sh" "./install.sh"   "%{_:lib}%"] # {!(os = "win32")}
-]
 url {
-  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.1.0/downloads/src.dkml-runtime-common.tar.gz"
+  src:
+    "https://github.com/diskuv/dkml-runtime-common/releases/download/2.1.0/src.tar.gz"
   checksum: [
-    "sha512=67f8bd51eb398daa3968dcf118d6b9fbb0418c70910f2ae401fad4261e382fe799a744acfbc15527fa8e8a35a75308246db7ca3e3d1134fd5063335b14a67f38"
+    "md5=7b89f1b8cbe4b87d311612268c3e97a8"
+    "sha512=6907df25e210d267aa482c05761deba685a9dbd93bcbc7a6b59d1d2b33a7235106d36b4bc82eb6fe2ddf18daf3531dd9e0cf39442f734ab0a44f0287b6e5fcf4"
   ]
 }

--- a/packages/dkml-runtime-common/dkml-runtime-common.2.1.0/opam
+++ b/packages/dkml-runtime-common/dkml-runtime-common.2.1.0/opam
@@ -1,24 +1,25 @@
 opam-version: "2.0"
 synopsis: "Common runtime code used in DKML"
-description: "Common runtime code used in DKML.
+description: """\
+Common runtime code used in DKML.
 
 The runtime code will be available in the 'lib/dkml-runtime-common' folder
-of your Opam switch or findlib installation."
-maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
-authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+of your Opam switch or findlib installation."""
+maintainer: "opensource+diskuv-ocaml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"
 license: "Apache-2.0"
 homepage: "https://github.com/diskuv/dkml-runtime-common"
 bug-reports: "https://github.com/diskuv/dkml-runtime-common/issues"
-dev-repo: "git+https://github.com/diskuv/dkml-runtime-common.git"
 depends: [
   "dune" {>= "2.9"}
 ]
-build: [
-  ["dune" "build" "-p" name]
-]
+build: ["dune" "build" "-p" name]
+dev-repo: "git+https://github.com/diskuv/dkml-runtime-common.git"
 url {
-  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.1.0/downloads/src.dkml-runtime-common.tar.gz"
+  src:
+    "https://github.com/diskuv/dkml-runtime-common/releases/download/2.1.0/src.tar.gz"
   checksum: [
-    "sha512=67f8bd51eb398daa3968dcf118d6b9fbb0418c70910f2ae401fad4261e382fe799a744acfbc15527fa8e8a35a75308246db7ca3e3d1134fd5063335b14a67f38"
+    "md5=7b89f1b8cbe4b87d311612268c3e97a8"
+    "sha512=6907df25e210d267aa482c05761deba685a9dbd93bcbc7a6b59d1d2b33a7235106d36b4bc82eb6fe2ddf18daf3531dd9e0cf39442f734ab0a44f0287b6e5fcf4"
   ]
 }


### PR DESCRIPTION
Common runtime code used in DKML

This pull-request concerns:
-`dkml-runtime-common.2.1.0`
-`dkml-runtime-common-native.2.1.0`



---
* Homepage: https://github.com/diskuv/dkml-runtime-common
* Source repo: git+https://github.com/diskuv/dkml-runtime-common.git
* Bug tracker: https://github.com/diskuv/dkml-runtime-common/issues

---
:camel: Pull-request generated by opam-publish v2.1.0