### PR TITLE
Package shexp.v0.16.0

### DIFF
--- a/packages/shexp/shexp.v0.16.0/opam
+++ b/packages/shexp/shexp.v0.16.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/shexp"
+bug-reports: "https://github.com/janestreet/shexp/issues"
+dev-repo: "git+https://github.com/janestreet/shexp.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/shexp/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"        {>= "4.14.0"}
+  "posixat"      {>= "v0.16" & < "v0.17"}
+  "sexplib0"     {>= "v0.16" & < "v0.17"}
+  "base-threads"
+  "dune"         {>= "2.0.0"}
+  "spawn"        {>= "v0.15"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Process library and s-expression based shell"
+description: "
+Shexp is composed of two parts: a library providing a process monad
+for shell scripting in OCaml as well as a simple s-expression based
+shell interpreter. Shexp works on both Unix and Windows.
+"
+url {
+  src:
+    "https://github.com/jonahbeckford/shexp/archive/refs/tags/v0.16.0-msvc.tar.gz"
+  checksum: [
+    "md5=9f91ae4e09f181088bf5daa1649dc2f6"
+    "sha512=1beedcae10d120f5d69b8fe7f1b739db598b86ac77a8dbc8ddeb4034391d162b00aac7d528a4c04f3483c103bd25416de90fb0d93536803c1d931a717e431f7c"
+  ]
+}


### PR DESCRIPTION
### `shexp.v0.16.0`
Process library and s-expression based shell
Shexp is composed of two parts: a library providing a process monad
for shell scripting in OCaml as well as a simple s-expression based
shell interpreter. Shexp works on both Unix and Windows.



---
* Homepage: https://github.com/janestreet/shexp
* Source repo: git+https://github.com/janestreet/shexp.git
* Bug tracker: https://github.com/janestreet/shexp/issues

---
:camel: Pull-request generated by opam-publish v2.2.0