### PR TITLE
5 packages from diskuv/dkml-component-opam at 2.2.0

### DIFF
--- a/packages/dkml-component-common-opam/dkml-component-common-opam.2.2.0/opam
+++ b/packages/dkml-component-common-opam/dkml-component-common-opam.2.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Common code for opam DkML components"
+description: "Common code for opam DkML components"
+maintainer: "opensource+dkml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-component-opam"
+bug-reports: "https://github.com/diskuv/dkml-component-opam/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "dkml-install" {>= "0.5.1"}
+  "cmdliner" {>= "1.2.0"}
+  "diskuvbox" {>= "0.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-component-opam.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-component-opam/releases/download/2.2.0.1/src.tar.gz"
+  checksum: [
+    "md5=96093b6cf38dc6aba193e946708a5a03"
+    "sha512=b35cb06041a0ae2d1514767b15afd2d5232c12ed61bea266046aef9007468fe976a9d1de86948c2d02c96347c162fa7abe54abc4c56dc0961fbaf7e70e15eff3"
+  ]
+}

--- a/packages/dkml-component-offline-opam/dkml-component-offline-opam.2.2.0/opam
+++ b/packages/dkml-component-offline-opam/dkml-component-offline-opam.2.2.0/opam
@@ -1,0 +1,76 @@
+opam-version: "2.0"
+synopsis: "Offline install of opam"
+description: """\
+Offline install that places opam in the installation directory.
+
+Depending on the end-user's integer size, as reported by Sys.int_size, either 32-bit or 64-bit opam will be installed.
+
+On macOS the end-user target ABI can be either darwin_arm64 or darwin_x86_64 when you have both dkml-base-compiler and
+conf-dkml-cross-toolchain installed in your switch, regardless whether your host's ABI is darwin_arm64 or darwin_x86.64.
+Otherwise on macOS the target ABI must match the host ABI.
+
+The package version, and what [opam --version] returns, are closely associated with the Opam version from the Opam
+source code. The only modifications are to ensure that the package version can be ordered using semver. In particular:
+
+* 2.2.0~alpha~dev -> 2.2.0~alpha0~20221231
+* 2.2.0~alpha~1   -> 2.2.0~alpha1~20230601
+* 2.2.0           -> 2.2.0
+
+The dates (YYYYMMDD) are the Git commit dates in the Opam source code, and simply replacing the tildes (~) with dashes (-) is
+sufficient to be compatible with semver and winget version ordering.
+
+Includes a patch to distinguish MSYS2 from Cygwin, esp. for rsync rather than symlinking which is needed on MSYS2."""
+maintainer: "opensource+dkml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-component-opam"
+bug-reports: "https://github.com/diskuv/dkml-component-opam/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "dkml-component-common-opam" {= version}
+  "dkml-component-staging-opam32" {= version}
+  "dkml-component-staging-opam64" {= version}
+  "dkml-component-staging-ocamlrun" {>= "4.12.1~"}
+  "dkml-install" {>= "0.5.1"}
+  "diskuvbox" {>= "0.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+install: [
+  [
+    "diskuvbox"
+    "copy-dir"
+    "assets/staging-files/win32"
+    "%{_:share}%/staging-files/windows_x86"
+  ]
+  [
+    "diskuvbox"
+    "copy-dir"
+    "assets/staging-files/win32"
+    "%{_:share}%/staging-files/windows_x86_64"
+  ]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-component-opam.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-component-opam/releases/download/2.2.0.1/src.tar.gz"
+  checksum: [
+    "md5=96093b6cf38dc6aba193e946708a5a03"
+    "sha512=b35cb06041a0ae2d1514767b15afd2d5232c12ed61bea266046aef9007468fe976a9d1de86948c2d02c96347c162fa7abe54abc4c56dc0961fbaf7e70e15eff3"
+  ]
+}

--- a/packages/dkml-component-offline-opamshim/dkml-component-offline-opamshim.2.2.0/opam
+++ b/packages/dkml-component-offline-opamshim/dkml-component-offline-opamshim.2.2.0/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+synopsis: "Offline install of opam shim"
+description: """\
+Offline install that places the opam shim and the real opam in the installation directory.
+
+The opam shim updates the PATH and compiler environment variables, especially for Windows, and then delegates
+to the real opam. The real opam is first checked in LOCALAPPDATA/Programs/opam/bin/opam.exe on Windows or
+~/.local/bin/opam on *nix machines. If that does not exist, the real opam in the installation directory is
+used. In this manner the authoritative, centrally installed opam.exe is always used.
+
+Depending on the end-user's integer size, as reported by Sys.int_size, either 32-bit or 64-bit opam will be installed.
+
+On macOS the end-user target ABI can be either darwin_arm64 or darwin_x86_64 when you have both dkml-base-compiler and
+conf-dkml-cross-toolchain installed in your switch, regardless whether your host's ABI is darwin_arm64 or darwin_x86.64.
+Otherwise on macOS the target ABI must match the host ABI.
+
+The package version, and what [opam --version] returns, are closely associated with the Opam version from the Opam
+source code. The only modifications are to ensure that the package version can be ordered using semver. In particular:
+
+* 2.2.0~alpha~dev -> 2.2.0~alpha0~20221231
+* 2.2.0~alpha~1   -> 2.2.0~alpha1~20230601
+* 2.2.0           -> 2.2.0
+
+The dates (YYYYMMDD) are the Git commit dates in the Opam source code, and simply replacing the tildes (~) with dashes (-) is
+sufficient to be compatible with semver and winget version ordering.
+
+Includes a patch to distinguish MSYS2 from Cygwin, esp. for rsync rather than symlinking which is needed on MSYS2."""
+maintainer: "opensource+dkml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-component-opam"
+bug-reports: "https://github.com/diskuv/dkml-component-opam/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "dkml-component-common-opam" {= version}
+  "dkml-component-staging-opam32" {= version}
+  "dkml-component-staging-opam64" {= version}
+  "dkml-component-staging-withdkml" {>= "0.1.0"}
+  "dkml-component-staging-ocamlrun" {>= "4.12.1~"}
+  "dkml-install" {>= "0.5.1"}
+  "diskuvbox" {>= "0.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-component-opam.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-component-opam/releases/download/2.2.0.1/src.tar.gz"
+  checksum: [
+    "md5=96093b6cf38dc6aba193e946708a5a03"
+    "sha512=b35cb06041a0ae2d1514767b15afd2d5232c12ed61bea266046aef9007468fe976a9d1de86948c2d02c96347c162fa7abe54abc4c56dc0961fbaf7e70e15eff3"
+  ]
+}

--- a/packages/dkml-component-staging-opam32/dkml-component-staging-opam32.2.2.0/opam
+++ b/packages/dkml-component-staging-opam32/dkml-component-staging-opam32.2.2.0/opam
@@ -1,0 +1,260 @@
+opam-version: "2.0"
+synopsis: "DkML component for 32-bit versions of opam"
+description: """\
+For 32-bit capable platforms, opam, opam-putenv and opam-installer will be in <share>/staging-files/<platform>.
+But for any platform that does not support 32-bit, this package will install nothing (aka. be a no-op).
+Consumers of the component should place both tools/opam64 and tools/opam32 into the PATH, so that whichever is available can be used.
+
+The package version, and what [opam --version] returns, are closely associated with the Opam version from the Opam
+source code. The only modifications are to ensure that the package version can be ordered using semver. In particular:
+
+* 2.2.0~alpha~dev -> 2.2.0~alpha0~20221231
+* 2.2.0~alpha~1   -> 2.2.0~alpha1~20230601
+* 2.2.0           -> 2.2.0
+
+The dates (YYYYMMDD) are the Git commit dates in the Opam source code, and simply replacing the tildes (~) with dashes (-) is
+sufficient to be compatible with semver and winget version ordering.
+
+Includes a patch to distinguish MSYS2 from Cygwin, esp. for rsync rather than symlinking which is needed on MSYS2."""
+maintainer: "opensource+dkml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-component-opam"
+bug-reports: "https://github.com/diskuv/dkml-component-opam/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.1~"}
+  "dkml-install" {>= "0.5.1"}
+  "dkml-runtime-common" {>= "2.0.3"}
+  "cmdliner" {>= "1.2.0"}
+  "diskuvbox" {>= "0.2.0"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "ocaml-system"
+  "dkml-base-compiler"
+  "ocaml-base-compiler"
+  "ocaml-variants"
+  "ocaml-option-32bit"
+]
+build: [
+  ["install" "-d" "dl/opam"]
+  ["tar" "xCfz" "dl/opam" "dl/opam.tar.gz" "--strip-components=1"]
+  [
+    "diskuvbox"
+    "copy-dir"
+    "%{dkml-runtime-common:lib}%/unix"
+    "dkmldir/vendor/drc/unix"
+  ]
+  [
+    "diskuvbox"
+    "copy-file"
+    "%{dkml-runtime-common:lib}%/template.dkmlroot"
+    "dkmldir/.dkmlroot"
+  ]
+  [
+    "diskuvbox"
+    "copy-dir"
+    "src/repro"
+    "dkmldir/vendor/component-opam/src/repro/"
+  ]
+  ["install" "-d" "dkmldir/vendor/dkml-compiler/src"]
+  [
+    "tar"
+    "xCfz"
+    "dkmldir/vendor/dkml-compiler"
+    "dl/dkml-compiler.tar.gz"
+    "--strip-components=1"
+  ]
+  ["sh" "%{dkml-runtime-common:lib}%/macos/brewbundle.sh"]
+    {os-distribution = "homebrew"}
+  [
+    "env"
+    "DKML_REPRODUCIBLE_SYSTEM_BREWFILE=%{_:build}%/Brewfile"
+    "dkmldir/vendor/component-opam/src/repro/r-c-opam-1-setup.sh"
+    "-d"
+    "dkmldir"
+    "-t"
+    "_w"
+    "-v"
+    "dl/opam"
+    "-p"
+    "%{_:version}%"
+    "-c"
+      {ocaml-base-compiler:installed | dkml-base-compiler:installed |
+       ocaml-variants:installed}
+    "%{prefix}%"
+      {ocaml-base-compiler:installed | dkml-base-compiler:installed |
+       ocaml-variants:installed}
+    "-f" {ocaml-system:installed}
+    "%{ocaml-system:path}%" {ocaml-system:installed}
+    "-awindows_x86"
+      {os = "win32" & (ocaml-option-32bit:installed | arch = "x86_32")}
+    "-alinux_x86" {os = "linux" & arch = "x86_32"}
+  ]
+    {os = "linux" & arch = "x86_32" |
+     os = "win32" & (ocaml-option-32bit:installed | arch = "x86_32")}
+  [
+    "sh"
+    "-eufc"
+    "cd _w && share/dkml/repro/110co/vendor/component-opam/src/repro/r-c-opam-2-build-noargs.sh"
+  ]
+    {os = "linux" & arch = "x86_32" |
+     os = "win32" & (ocaml-option-32bit:installed | arch = "x86_32")}
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+install: [
+  [
+    "diskuvbox"
+    "copy-file-into"
+    "_w/bin/opam"
+    "_w/bin/opam-installer"
+    "%{_:share}%/staging-files/linux_x86/bin"
+  ] {os = "linux" & arch = "x86_32"}
+  [
+    "diskuvbox"
+    "copy-file-into"
+    "_w/bin/opam.exe"
+    "_w/bin/opam-installer.exe"
+    "_w/bin/opam-putenv.exe"
+    "%{_:share}%/staging-files/windows_x86/bin"
+  ] {os = "win32" & (ocaml-option-32bit:installed | arch = "x86_32")}
+  [
+    "diskuvbox"
+    "copy-dir"
+    "_w/share/man"
+    "%{_:share}%/staging-files/generic/man"
+  ]
+    {os = "linux" & arch = "x86_32" |
+     os = "win32" & (ocaml-option-32bit:installed | arch = "x86_32")}
+]
+dev-repo: "git+https://github.com/diskuv/dkml-component-opam.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-component-opam/releases/download/2.2.0.1/src.tar.gz"
+  checksum: [
+    "md5=96093b6cf38dc6aba193e946708a5a03"
+    "sha512=b35cb06041a0ae2d1514767b15afd2d5232c12ed61bea266046aef9007468fe976a9d1de86948c2d02c96347c162fa7abe54abc4c56dc0961fbaf7e70e15eff3"
+  ]
+}
+extra-source "dl/dkml-compiler.tar.gz" {
+  src:
+    "https://github.com/diskuv/dkml-compiler/releases/download/2.1.0-2/src.tar.gz"
+  checksum:
+    "sha256=11cd6c70ff2e5aaa588bfb7658dba12e862885da2db825090aa7b3451b647c1e"
+}
+extra-source "dl/homebrew-bundle.tar.gz" {
+  src:
+    "https://github.com/Homebrew/homebrew-bundle/archive/437c67db2f160369fec3a3892e3c577b6b3a4d2c.tar.gz"
+  checksum:
+    "sha256=ecb6b03b2d0210369f23e3f8f64cd939a4bba633db08db62a49894653e053df4"
+}
+extra-source "dl/opam.tar.gz" {
+  src:
+    "https://github.com/ocaml/opam/releases/download/2.2.0/opam-full-2.2.0-2.tar.gz"
+  checksum:
+    "sha256=459ed64e6643f05c677563a000e3baa05c76ce528064e9cb9ce6db49fff37c97"
+}
+extra-source "dl/opam/src_ext/archives/0.1.tar.gz" {
+  src: "https://github.com/OCamlPro/swhid_core/archive/refs/tags/0.1.tar.gz"
+  checksum: "md5=77d88d4b1d96261c866f140c64d89af8"
+}
+extra-source "dl/opam/src_ext/archives/0.43.tar.gz" {
+  src: "https://github.com/ocaml/flexdll/archive/0.43.tar.gz"
+  checksum: "md5=6ce706f6c65b2c5adf5791fac678f090"
+}
+extra-source "dl/opam/src_ext/archives/1.1+17.tar.gz" {
+  src:
+    "https://github.com/ocaml-opam/ocaml-mccs/archive/refs/tags/1.1+17.tar.gz"
+  checksum: "md5=844d99bc531e0713238fe4b6b8511ed1"
+}
+extra-source "dl/opam/src_ext/archives/2.1.6.tar.gz" {
+  src:
+    "https://github.com/ocaml/opam-file-format/archive/refs/tags/2.1.6.tar.gz"
+  checksum: "md5=706ce5fc3e77db746a4c8b11d79cefef"
+}
+extra-source "dl/opam/src_ext/archives/4.14.2.tar.gz" {
+  src: "https://github.com/ocaml/ocaml/archive/refs/tags/4.14.2.tar.gz"
+  checksum: "md5=b28daefda803b5d5910cecf085b1451c"
+}
+extra-source "dl/opam/src_ext/archives/base64-3.5.1.tbz" {
+  src:
+    "https://github.com/mirage/ocaml-base64/releases/download/v3.5.1/base64-3.5.1.tbz"
+  checksum: "md5=bfdd16aa8c136412878109df8791fc01"
+}
+extra-source "dl/opam/src_ext/archives/cmdliner-1.3.0.tbz" {
+  src: "https://erratique.ch/software/cmdliner/releases/cmdliner-1.3.0.tbz"
+  checksum: "md5=662936095a1613d7254815238e11793f"
+}
+extra-source "dl/opam/src_ext/archives/cudf-v0.10.tar.gz" {
+  src: "https://gitlab.com/irill/cudf/-/archive/v0.10/cudf-v0.10.tar.gz"
+  checksum: "md5=ed8fea314d0c6dc0d8811ccf860c53dd"
+}
+extra-source "dl/opam/src_ext/archives/dose3-7.0.0.tar.gz" {
+  src: "https://gitlab.com/irill/dose3/-/archive/7.0.0/dose3-7.0.0.tar.gz"
+  checksum: "md5=bc99cbcea8fca29dca3ebbee54be45e1"
+}
+extra-source "dl/opam/src_ext/archives/extlib-1.7.9.tar.gz" {
+  src:
+    "https://github.com/ygrek/ocaml-extlib/releases/download/1.7.9/extlib-1.7.9.tar.gz"
+  checksum: "md5=f7ca7f1c82e15a99603b88f730fd7b8a"
+}
+extra-source "dl/opam/src_ext/archives/jsonm-1.0.2.tbz" {
+  src: "https://erratique.ch/software/jsonm/releases/jsonm-1.0.2.tbz"
+  checksum: "md5=bb21574ddd58543120430ff306b462e6"
+}
+extra-source "dl/opam/src_ext/archives/ocamlgraph-2.1.0.tbz" {
+  src:
+    "https://github.com/backtracking/ocamlgraph/releases/download/2.1.0/ocamlgraph-2.1.0.tbz"
+  checksum: "md5=4200d8f223aa7a32b4024e4553821c7c"
+}
+extra-source "dl/opam/src_ext/archives/opam-0install-cudf-0.4.3.tbz" {
+  src:
+    "https://github.com/ocaml-opam/opam-0install-solver/releases/download/v0.4.3/opam-0install-cudf-0.4.3.tbz"
+  checksum: "md5=ae0c197deace373ad87737468a04f76b"
+}
+extra-source "dl/opam/src_ext/archives/re-1.11.0.tbz" {
+  src:
+    "https://github.com/ocaml/ocaml-re/releases/download/1.11.0/re-1.11.0.tbz"
+  checksum: "md5=e0199e32947fd33fcc1b8e69de2308a1"
+}
+extra-source "dl/opam/src_ext/archives/sha-1.15.4.tbz" {
+  src:
+    "https://github.com/djs55/ocaml-sha/releases/download/v1.15.4/sha-1.15.4.tbz"
+  checksum: "md5=08bc953d9a26380bc220b05d680791fb"
+}
+extra-source "dl/opam/src_ext/archives/spdx_licenses-1.2.0.tar.gz" {
+  src:
+    "https://github.com/kit-ty-kate/spdx_licenses/releases/download/v1.2.0/spdx_licenses-1.2.0.tar.gz"
+  checksum: "md5=b581124aeebd7facb856d8b942cb58a5"
+}
+extra-source "dl/opam/src_ext/archives/stdlib-shims-0.3.0.tbz" {
+  src:
+    "https://github.com/ocaml/stdlib-shims/releases/download/0.3.0/stdlib-shims-0.3.0.tbz"
+  checksum: "md5=09db7af8b4a3a96048a61cb6ae2496ef"
+}
+extra-source "dl/opam/src_ext/archives/uutf-1.0.3.tbz" {
+  src: "https://erratique.ch/software/uutf/releases/uutf-1.0.3.tbz"
+  checksum: "md5=a308285514259d20b48abc92f00a3708"
+}
+extra-source "dl/opam/src_ext/archives/v0.3.1.tar.gz" {
+  src: "https://github.com/c-cube/seq/archive/v0.3.1.tar.gz"
+  checksum: "md5=de05d9dedd492fa4e3c0c87bc2792475"
+}
+extra-source "dl/opam/src_ext/archives/v1.6.9.tar.gz" {
+  src: "https://github.com/ocaml-community/cppo/archive/v1.6.9.tar.gz"
+  checksum: "md5=d23ffe85ac7dc8f0afd1ddf622770d09"
+}

--- a/packages/dkml-component-staging-opam64/dkml-component-staging-opam64.2.2.0/opam
+++ b/packages/dkml-component-staging-opam64/dkml-component-staging-opam64.2.2.0/opam
@@ -1,0 +1,310 @@
+opam-version: "2.0"
+synopsis: "DkML component for 64-bit versions of opam"
+description: """\
+For 64-bit capable platforms, opam, opam-putenv and opam-installer will be in <share>/staging-files/<platform>.
+But for any platform that does not support 64-bit, this package will install nothing (aka. be a no-op).
+Consumers of the component should place both tools/opam64 and tools/opam32 into the PATH, so that whichever is available can be used.
+
+Cross-compiling to both darwin_arm64 and darwin_x86_64 platforms are supported on macOS when you have both dkml-base-compiler and
+conf-dkml-cross-toolchain installed in your switch.
+
+The package version, and what [opam --version] returns, are closely associated with the Opam version from the Opam
+source code. The only modifications are to ensure that the package version can be ordered using semver. In particular:
+
+* 2.2.0~alpha~dev -> 2.2.0~alpha0~20221231
+* 2.2.0~alpha~1   -> 2.2.0~alpha1~20230601
+* 2.2.0           -> 2.2.0
+
+The dates (YYYYMMDD) are the Git commit dates in the Opam source code, and simply replacing the tildes (~) with dashes (-) is
+sufficient to be compatible with semver and winget version ordering.
+
+Includes a patch to distinguish MSYS2 from Cygwin, esp. for rsync rather than symlinking which is needed on MSYS2."""
+maintainer: "opensource+dkml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-component-opam"
+bug-reports: "https://github.com/diskuv/dkml-component-opam/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.1~"}
+  "dkml-install" {>= "0.5.1"}
+  "dkml-runtime-common" {>= "2.0.3"}
+  "cmdliner" {>= "1.2.0"}
+  "diskuvbox" {>= "0.2.0"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "ocaml-system"
+  "dkml-base-compiler"
+  "ocaml-base-compiler"
+  "ocaml-variants"
+  "conf-dkml-cross-toolchain"
+  "ocaml-option-32bit"
+]
+build: [
+  ["install" "-d" "dl/opam"]
+  ["tar" "xCfz" "dl/opam" "dl/opam.tar.gz" "--strip-components=1"]
+  [
+    "diskuvbox"
+    "copy-file"
+    "assets/dune-workspace.darwin_x86_64" {arch = "x86_64"}
+    "assets/dune-workspace.darwin_arm64" {arch = "arm64"}
+    "dl/opam/dune-workspace"
+  ]
+    {os = "macos" & (arch = "x86_64" | arch = "arm64") &
+     dkml-base-compiler:installed &
+     conf-dkml-cross-toolchain:installed}
+  [
+    "diskuvbox"
+    "copy-dir"
+    "%{dkml-runtime-common:lib}%/unix"
+    "dkmldir/vendor/drc/unix"
+  ]
+  [
+    "diskuvbox"
+    "copy-file"
+    "%{dkml-runtime-common:lib}%/template.dkmlroot"
+    "dkmldir/.dkmlroot"
+  ]
+  [
+    "diskuvbox"
+    "copy-dir"
+    "src/repro"
+    "dkmldir/vendor/component-opam/src/repro/"
+  ]
+  ["install" "-d" "dkmldir/vendor/dkml-compiler/src"]
+  [
+    "tar"
+    "xCfz"
+    "dkmldir/vendor/dkml-compiler"
+    "dl/dkml-compiler.tar.gz"
+    "--strip-components=1"
+  ]
+  ["sh" "%{dkml-runtime-common:lib}%/macos/brewbundle.sh"]
+    {os-distribution = "homebrew"}
+  [
+    "env"
+    "DKML_REPRODUCIBLE_SYSTEM_BREWFILE=%{_:build}%/Brewfile"
+    "bash"
+    "-x"
+    "dkmldir/vendor/component-opam/src/repro/r-c-opam-1-setup.sh"
+    "-d"
+    "dkmldir"
+    "-t"
+    "_w"
+    "-v"
+    "dl/opam"
+    "-p"
+    "%{_:version}%"
+    "-c"
+      {ocaml-base-compiler:installed | dkml-base-compiler:installed |
+       ocaml-variants:installed}
+    "%{prefix}%"
+      {ocaml-base-compiler:installed | dkml-base-compiler:installed |
+       ocaml-variants:installed}
+    "-f" {ocaml-system:installed}
+    "%{ocaml-system:path}%" {ocaml-system:installed}
+    "-awindows_x86_64"
+      {os = "win32" & !ocaml-option-32bit:installed & arch = "x86_64"}
+    "-alinux_x86_64" {os = "linux" & arch = "x86_64"}
+    "-adarwin_arm64" {os = "macos" & arch = "arm64"}
+    "-adarwin_x86_64" {os = "macos" & arch = "x86_64"}
+  ]
+    {os = "macos" | os = "linux" & arch = "x86_64" |
+     os = "win32" & !ocaml-option-32bit:installed & arch = "x86_64"}
+  [
+    "sh"
+    "-eufc"
+    "cd _w && share/dkml/repro/110co/vendor/component-opam/src/repro/r-c-opam-2-build-noargs.sh"
+  ]
+    {os = "macos" | os = "linux" & arch = "x86_64" |
+     os = "win32" & !ocaml-option-32bit:installed & arch = "x86_64"}
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+install: [
+  [
+    "diskuvbox"
+    "copy-file-into"
+    "_w/bin/opam"
+    "_w/bin/opam-installer"
+    "%{_:share}%/staging-files/darwin_x86_64/bin"
+  ] {os = "macos" & arch = "x86_64"}
+  [
+    "diskuvbox"
+    "copy-file-into"
+    "_w/bin/opam"
+    "_w/bin/opam-installer"
+    "%{_:share}%/staging-files/darwin_arm64/bin"
+  ] {os = "macos" & arch = "arm64"}
+  [
+    "diskuvbox"
+    "copy-file-into"
+    "_w/bin/opam"
+    "_w/bin/opam-installer"
+    "%{_:share}%/staging-files/linux_x86_64/bin"
+  ] {os = "linux" & arch = "x86_64"}
+  [
+    "diskuvbox"
+    "copy-file-into"
+    "_w/bin/opam.exe"
+    "_w/bin/opam-installer.exe"
+    "_w/bin/opam-putenv.exe"
+    "%{_:share}%/staging-files/windows_x86_64/bin"
+  ] {os = "win32" & !ocaml-option-32bit:installed & arch = "x86_64"}
+  [
+    "diskuvbox"
+    "copy-file-into"
+    "_w/src/opam/_build/install/default.darwin_arm64/bin/opam"
+    "_w/src/opam/_build/install/default.darwin_arm64/bin/opam-installer"
+    "%{_:share}%/staging-files/darwin_arm64/bin"
+  ]
+    {os = "macos" & arch = "x86_64" & dkml-base-compiler:installed &
+     conf-dkml-cross-toolchain:installed}
+  [
+    "diskuvbox"
+    "copy-file-into"
+    "_w/src/opam/_build/install/default.darwin_x86_64/bin/opam"
+    "_w/src/opam/_build/install/default.darwin_x86_64/bin/opam-installer"
+    "%{_:share}%/staging-files/darwin_x86_64/bin"
+  ]
+    {os = "macos" & arch = "arm64" & dkml-base-compiler:installed &
+     conf-dkml-cross-toolchain:installed}
+  [
+    "diskuvbox"
+    "copy-dir"
+    "_w/share/man"
+    "%{_:share}%/staging-files/generic/man"
+  ]
+    {os = "macos" | os = "linux" & arch = "x86_64" |
+     os = "win32" & !ocaml-option-32bit:installed & arch = "x86_64"}
+]
+dev-repo: "git+https://github.com/diskuv/dkml-component-opam.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-component-opam/releases/download/2.2.0.1/src.tar.gz"
+  checksum: [
+    "md5=96093b6cf38dc6aba193e946708a5a03"
+    "sha512=b35cb06041a0ae2d1514767b15afd2d5232c12ed61bea266046aef9007468fe976a9d1de86948c2d02c96347c162fa7abe54abc4c56dc0961fbaf7e70e15eff3"
+  ]
+}
+extra-source "dl/dkml-compiler.tar.gz" {
+  src:
+    "https://github.com/diskuv/dkml-compiler/releases/download/2.1.0-2/src.tar.gz"
+  checksum:
+    "sha256=11cd6c70ff2e5aaa588bfb7658dba12e862885da2db825090aa7b3451b647c1e"
+}
+extra-source "dl/homebrew-bundle.tar.gz" {
+  src:
+    "https://github.com/Homebrew/homebrew-bundle/archive/437c67db2f160369fec3a3892e3c577b6b3a4d2c.tar.gz"
+  checksum:
+    "sha256=ecb6b03b2d0210369f23e3f8f64cd939a4bba633db08db62a49894653e053df4"
+}
+extra-source "dl/opam.tar.gz" {
+  src:
+    "https://github.com/ocaml/opam/releases/download/2.2.0/opam-full-2.2.0-2.tar.gz"
+  checksum:
+    "sha256=459ed64e6643f05c677563a000e3baa05c76ce528064e9cb9ce6db49fff37c97"
+}
+extra-source "dl/opam/src_ext/archives/0.1.tar.gz" {
+  src: "https://github.com/OCamlPro/swhid_core/archive/refs/tags/0.1.tar.gz"
+  checksum: "md5=77d88d4b1d96261c866f140c64d89af8"
+}
+extra-source "dl/opam/src_ext/archives/0.43.tar.gz" {
+  src: "https://github.com/ocaml/flexdll/archive/0.43.tar.gz"
+  checksum: "md5=6ce706f6c65b2c5adf5791fac678f090"
+}
+extra-source "dl/opam/src_ext/archives/1.1+17.tar.gz" {
+  src:
+    "https://github.com/ocaml-opam/ocaml-mccs/archive/refs/tags/1.1+17.tar.gz"
+  checksum: "md5=844d99bc531e0713238fe4b6b8511ed1"
+}
+extra-source "dl/opam/src_ext/archives/2.1.6.tar.gz" {
+  src:
+    "https://github.com/ocaml/opam-file-format/archive/refs/tags/2.1.6.tar.gz"
+  checksum: "md5=706ce5fc3e77db746a4c8b11d79cefef"
+}
+extra-source "dl/opam/src_ext/archives/4.14.2.tar.gz" {
+  src: "https://github.com/ocaml/ocaml/archive/refs/tags/4.14.2.tar.gz"
+  checksum: "md5=b28daefda803b5d5910cecf085b1451c"
+}
+extra-source "dl/opam/src_ext/archives/base64-3.5.1.tbz" {
+  src:
+    "https://github.com/mirage/ocaml-base64/releases/download/v3.5.1/base64-3.5.1.tbz"
+  checksum: "md5=bfdd16aa8c136412878109df8791fc01"
+}
+extra-source "dl/opam/src_ext/archives/cmdliner-1.3.0.tbz" {
+  src: "https://erratique.ch/software/cmdliner/releases/cmdliner-1.3.0.tbz"
+  checksum: "md5=662936095a1613d7254815238e11793f"
+}
+extra-source "dl/opam/src_ext/archives/cudf-v0.10.tar.gz" {
+  src: "https://gitlab.com/irill/cudf/-/archive/v0.10/cudf-v0.10.tar.gz"
+  checksum: "md5=ed8fea314d0c6dc0d8811ccf860c53dd"
+}
+extra-source "dl/opam/src_ext/archives/dose3-7.0.0.tar.gz" {
+  src: "https://gitlab.com/irill/dose3/-/archive/7.0.0/dose3-7.0.0.tar.gz"
+  checksum: "md5=bc99cbcea8fca29dca3ebbee54be45e1"
+}
+extra-source "dl/opam/src_ext/archives/extlib-1.7.9.tar.gz" {
+  src:
+    "https://github.com/ygrek/ocaml-extlib/releases/download/1.7.9/extlib-1.7.9.tar.gz"
+  checksum: "md5=f7ca7f1c82e15a99603b88f730fd7b8a"
+}
+extra-source "dl/opam/src_ext/archives/jsonm-1.0.2.tbz" {
+  src: "https://erratique.ch/software/jsonm/releases/jsonm-1.0.2.tbz"
+  checksum: "md5=bb21574ddd58543120430ff306b462e6"
+}
+extra-source "dl/opam/src_ext/archives/ocamlgraph-2.1.0.tbz" {
+  src:
+    "https://github.com/backtracking/ocamlgraph/releases/download/2.1.0/ocamlgraph-2.1.0.tbz"
+  checksum: "md5=4200d8f223aa7a32b4024e4553821c7c"
+}
+extra-source "dl/opam/src_ext/archives/opam-0install-cudf-0.4.3.tbz" {
+  src:
+    "https://github.com/ocaml-opam/opam-0install-solver/releases/download/v0.4.3/opam-0install-cudf-0.4.3.tbz"
+  checksum: "md5=ae0c197deace373ad87737468a04f76b"
+}
+extra-source "dl/opam/src_ext/archives/re-1.11.0.tbz" {
+  src:
+    "https://github.com/ocaml/ocaml-re/releases/download/1.11.0/re-1.11.0.tbz"
+  checksum: "md5=e0199e32947fd33fcc1b8e69de2308a1"
+}
+extra-source "dl/opam/src_ext/archives/sha-1.15.4.tbz" {
+  src:
+    "https://github.com/djs55/ocaml-sha/releases/download/v1.15.4/sha-1.15.4.tbz"
+  checksum: "md5=08bc953d9a26380bc220b05d680791fb"
+}
+extra-source "dl/opam/src_ext/archives/spdx_licenses-1.2.0.tar.gz" {
+  src:
+    "https://github.com/kit-ty-kate/spdx_licenses/releases/download/v1.2.0/spdx_licenses-1.2.0.tar.gz"
+  checksum: "md5=b581124aeebd7facb856d8b942cb58a5"
+}
+extra-source "dl/opam/src_ext/archives/stdlib-shims-0.3.0.tbz" {
+  src:
+    "https://github.com/ocaml/stdlib-shims/releases/download/0.3.0/stdlib-shims-0.3.0.tbz"
+  checksum: "md5=09db7af8b4a3a96048a61cb6ae2496ef"
+}
+extra-source "dl/opam/src_ext/archives/uutf-1.0.3.tbz" {
+  src: "https://erratique.ch/software/uutf/releases/uutf-1.0.3.tbz"
+  checksum: "md5=a308285514259d20b48abc92f00a3708"
+}
+extra-source "dl/opam/src_ext/archives/v0.3.1.tar.gz" {
+  src: "https://github.com/c-cube/seq/archive/v0.3.1.tar.gz"
+  checksum: "md5=de05d9dedd492fa4e3c0c87bc2792475"
+}
+extra-source "dl/opam/src_ext/archives/v1.6.9.tar.gz" {
+  src: "https://github.com/ocaml-community/cppo/archive/v1.6.9.tar.gz"
+  checksum: "md5=d23ffe85ac7dc8f0afd1ddf622770d09"
+}


### PR DESCRIPTION
This pull-request concerns:
-`dkml-component-common-opam.2.2.0`: Common code for opam DkML components
-`dkml-component-offline-opam.2.2.0`: Offline install of opam
-`dkml-component-offline-opamshim.2.2.0`: Offline install of opam shim
-`dkml-component-staging-opam32.2.2.0`: DkML component for 32-bit versions of opam
-`dkml-component-staging-opam64.2.2.0`: DkML component for 64-bit versions of opam



---
* Homepage: https://github.com/diskuv/dkml-component-opam
* Source repo: git+https://github.com/diskuv/dkml-component-opam.git
* Bug tracker: https://github.com/diskuv/dkml-component-opam/issues

---
:camel: Pull-request generated by opam-publish v2.1.0