### PR TITLE
5 packages from diskuv/dkml-component-opam at 2.2.0.1

### DIFF
--- a/packages/dkml-component-common-opam/dkml-component-common-opam.2.2.0.1/opam
+++ b/packages/dkml-component-common-opam/dkml-component-common-opam.2.2.0.1/opam
@@ -34,7 +34,7 @@ url {
   src:
     "https://github.com/diskuv/dkml-component-opam/releases/download/2.2.0.1/src.tar.gz"
   checksum: [
-    "md5=96093b6cf38dc6aba193e946708a5a03"
-    "sha512=b35cb06041a0ae2d1514767b15afd2d5232c12ed61bea266046aef9007468fe976a9d1de86948c2d02c96347c162fa7abe54abc4c56dc0961fbaf7e70e15eff3"
+    "md5=10b4e498bd71af9cb78861e120207e95"
+    "sha512=5f3b8ac909cf696615a784d3b50cffdf9be5a6ad87201ab08e76311f1d882712339c40f86ddf60fd1b745fbfb17ede5d2f2797c2d491a69caff01c96bbb7538c"
   ]
 }

--- a/packages/dkml-component-offline-opam/dkml-component-offline-opam.2.2.0.1/opam
+++ b/packages/dkml-component-offline-opam/dkml-component-offline-opam.2.2.0.1/opam
@@ -70,7 +70,7 @@ url {
   src:
     "https://github.com/diskuv/dkml-component-opam/releases/download/2.2.0.1/src.tar.gz"
   checksum: [
-    "md5=96093b6cf38dc6aba193e946708a5a03"
-    "sha512=b35cb06041a0ae2d1514767b15afd2d5232c12ed61bea266046aef9007468fe976a9d1de86948c2d02c96347c162fa7abe54abc4c56dc0961fbaf7e70e15eff3"
+    "md5=10b4e498bd71af9cb78861e120207e95"
+    "sha512=5f3b8ac909cf696615a784d3b50cffdf9be5a6ad87201ab08e76311f1d882712339c40f86ddf60fd1b745fbfb17ede5d2f2797c2d491a69caff01c96bbb7538c"
   ]
 }

--- a/packages/dkml-component-offline-opamshim/dkml-component-offline-opamshim.2.2.0.1/opam
+++ b/packages/dkml-component-offline-opamshim/dkml-component-offline-opamshim.2.2.0.1/opam
@@ -62,7 +62,7 @@ url {
   src:
     "https://github.com/diskuv/dkml-component-opam/releases/download/2.2.0.1/src.tar.gz"
   checksum: [
-    "md5=96093b6cf38dc6aba193e946708a5a03"
-    "sha512=b35cb06041a0ae2d1514767b15afd2d5232c12ed61bea266046aef9007468fe976a9d1de86948c2d02c96347c162fa7abe54abc4c56dc0961fbaf7e70e15eff3"
+    "md5=10b4e498bd71af9cb78861e120207e95"
+    "sha512=5f3b8ac909cf696615a784d3b50cffdf9be5a6ad87201ab08e76311f1d882712339c40f86ddf60fd1b745fbfb17ede5d2f2797c2d491a69caff01c96bbb7538c"
   ]
 }

--- a/packages/dkml-component-staging-opam32/dkml-component-staging-opam32.2.2.0.1/opam
+++ b/packages/dkml-component-staging-opam32/dkml-component-staging-opam32.2.2.0.1/opam
@@ -146,8 +146,8 @@ url {
   src:
     "https://github.com/diskuv/dkml-component-opam/releases/download/2.2.0.1/src.tar.gz"
   checksum: [
-    "md5=96093b6cf38dc6aba193e946708a5a03"
-    "sha512=b35cb06041a0ae2d1514767b15afd2d5232c12ed61bea266046aef9007468fe976a9d1de86948c2d02c96347c162fa7abe54abc4c56dc0961fbaf7e70e15eff3"
+    "md5=10b4e498bd71af9cb78861e120207e95"
+    "sha512=5f3b8ac909cf696615a784d3b50cffdf9be5a6ad87201ab08e76311f1d882712339c40f86ddf60fd1b745fbfb17ede5d2f2797c2d491a69caff01c96bbb7538c"
   ]
 }
 extra-source "dl/dkml-compiler.tar.gz" {

--- a/packages/dkml-component-staging-opam64/dkml-component-staging-opam64.2.2.0.1/opam
+++ b/packages/dkml-component-staging-opam64/dkml-component-staging-opam64.2.2.0.1/opam
@@ -196,8 +196,8 @@ url {
   src:
     "https://github.com/diskuv/dkml-component-opam/releases/download/2.2.0.1/src.tar.gz"
   checksum: [
-    "md5=96093b6cf38dc6aba193e946708a5a03"
-    "sha512=b35cb06041a0ae2d1514767b15afd2d5232c12ed61bea266046aef9007468fe976a9d1de86948c2d02c96347c162fa7abe54abc4c56dc0961fbaf7e70e15eff3"
+    "md5=10b4e498bd71af9cb78861e120207e95"
+    "sha512=5f3b8ac909cf696615a784d3b50cffdf9be5a6ad87201ab08e76311f1d882712339c40f86ddf60fd1b745fbfb17ede5d2f2797c2d491a69caff01c96bbb7538c"
   ]
 }
 extra-source "dl/dkml-compiler.tar.gz" {


### PR DESCRIPTION
This pull-request concerns:
-`dkml-component-common-opam.2.2.0.1`: Common code for opam DkML components
-`dkml-component-offline-opam.2.2.0.1`: Offline install of opam
-`dkml-component-offline-opamshim.2.2.0.1`: Offline install of opam shim
-`dkml-component-staging-opam32.2.2.0.1`: DkML component for 32-bit versions of opam
-`dkml-component-staging-opam64.2.2.0.1`: DkML component for 64-bit versions of opam



---
* Homepage: https://github.com/diskuv/dkml-component-opam
* Source repo: git+https://github.com/diskuv/dkml-component-opam.git
* Bug tracker: https://github.com/diskuv/dkml-component-opam/issues

---
:camel: Pull-request generated by opam-publish v2.1.0