### PR TITLE
Package earlybird.1.3.2+dkml-4_14-backport-linearclosures

### DIFF
--- a/packages/earlybird/earlybird.1.3.2+dkml-4_14-backport-linearclosures/opam
+++ b/packages/earlybird/earlybird.1.3.2+dkml-4_14-backport-linearclosures/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/hackwaly/ocamlearlybird/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.14.2"}
-  "dkml-base-compiler" {>= "4.14.2" & < "5.0.0"}
+  "dkml-base-compiler" {>= "4.14.2~" & < "5.0.0~"}
   "ppx_deriving" {>= "5.1"}
   "ppx_deriving_yojson" {>= "3.6.1"}
   "menhir" {>= "20201216" & build}
@@ -48,7 +48,7 @@ url {
   src:
     "https://github.com/jonahbeckford/ocamlearlybird/releases/download/1.3.2%2Bdkml-4_14-backport-linearclosures/src.tar.gz"
   checksum: [
-    "md5=9680942f378f7a102fb0a678dc681d12"
-    "sha512=7f0e30cd71fc08ec284a10ad09c7f645cfac171a863d2b4ff15ad14978d62d95aeb6bef47ef31bc090bf62d6ebb3da4686eb8e570b7492014cbe70bf4609f236"
+    "md5=f9e2782f4d622440cbe88ff87d70247c"
+    "sha512=85e018774763ba0b69483c870900830d191bb78f56277d929f2b8219539ecb8474d76157a36b97906b68e41adb582441cb97ae1d7d8b72baed6a5269968e5776"
   ]
 }


### PR DESCRIPTION
### `earlybird.1.3.2+dkml-4_14-backport-linearclosures`
OCaml debug adapter



---
* Homepage: https://github.com/hackwaly/ocamlearlybird
* Source repo: git+https://github.com/hackwaly/ocamlearlybird.git
* Bug tracker: https://github.com/hackwaly/ocamlearlybird/issues

---
:camel: Pull-request generated by opam-publish v2.1.0