### PR TITLE
5 packages from diskuv/dkml-compiler at 2.1.4~r1

### DIFF
--- a/packages/dkml-base-compiler/dkml-base-compiler.2.1.4~r1/opam
+++ b/packages/dkml-base-compiler/dkml-base-compiler.2.1.4~r1/opam
@@ -1,0 +1,301 @@
+opam-version: "2.0"
+synopsis: "OCaml cross-compiler and libraries from the DkML distribution"
+description: """\
+The DkML distribution of the OCaml bytecode and native compiler, Stdlib and the other OCaml libraries (str, unix, bigarray, etc.).
+
+The following cross-compilers have been included:
+- from macOS x86_64 and macOS arm64, and vice versa
+- from Linux x86 to the android armeabi-v7a ABI
+- from Linux x86_64 to either the android arm64-v8a or x86_64 ABI
+
+To support cross-compilation, environment variables for compilers like CC and LDFLAGS have no effect on the 'host' ABI.
+The compiler for the 'host' ABI will be detected from conventional locations on the system and (for Visual Studio)
+from configuration stored in the DkML home directory.
+
+If you use cross-compilation, you should also install the conf-dkml-cross-toolchain package
+so that your findlib installation recognizes the cross-compilers.
+
+For Android compilation, the following opam global or switch variables are needed:
+- (required) ANDROID_NDK. This is the directory containing the Android NDK installation.
+  Examples: /opt/downloaded/ndk-23.1.7779620
+- (optional) ANDROID_PLATFORM. The minimum API level for the Android app or library. The default varies based on the version
+  of dkml-base-compiler, so it is best to set this. This version the default is 23.
+  Confer: https://developer.android.com/ndk/guides/cmake#android_platform.
+  Examples: android-23, 23, android-N, android-O_MR1
+
+Advanced: Set environment variables like DKML_TARGET_ABI and DKML_COMPILE_* to do cross-compilation from the 'host' ABI
+to a 'target' ABI. Those variables are documented in dkml-runtime-common's crossplatform-functions.sh script.
+Search for: autodetect_compiler()
+
+You can install dkml-base-compiler with something like:
+  opam switch create dkml-4.14.2 '--formula="dkml-base-compiler" {>= "4.14.2~" & < "4.15.0~"}'"""
+maintainer: "opensource+dkml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-compiler"
+bug-reports: "https://github.com/diskuv/dkml-compiler/issues"
+depends: [
+  "ocaml" {= "4.14.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "dkml-runtime-common" {= "2.1.3"}
+  "dkml-host-abi"
+  ("dkml-host-abi-darwin_arm64" | "dkml-host-abi-darwin_x86_64" |
+   "dkml-host-abi-linux_x86_64" |
+   "dkml-host-abi-linux_x86" |
+   "dkml-host-abi-windows_x86_64" |
+   "dkml-host-abi-windows_arm64" |
+   "dkml-host-abi-windows_x86")
+]
+depopts: [
+  "ocaml-option-32bit"
+  "dkml-option-debuginfo"
+  "dkml-option-minsize"
+  "dkml-target-abi-android_arm64v8a"
+  "dkml-target-abi-android_arm32v7a"
+  "dkml-target-abi-android_x86_64"
+  "dkml-target-abi-android_x86"
+  "dkml-target-abi-darwin_arm64"
+  "dkml-target-abi-darwin_x86_64"
+  "dkml-target-abi-linux_x86_64"
+  "dkml-target-abi-linux_x86"
+  "dkml-target-abi-windows_x86_64"
+  "dkml-target-abi-windows_arm64"
+  "dkml-target-abi-windows_x86"
+]
+conflict-class: "ocaml-core-compiler"
+available: opam-version >= "2.1.0"
+flags: [compiler avoid-version]
+build: [
+  [
+    "sh"
+    "-c"
+    """
+    echo 'FATAL: Installing an Android cross-compiler requires the ANDROID_NDK opam global or switch variable.';
+    echo 'It is recommended that you set ANDROID_PLATFORM (the minimum API level) as well.';
+    echo 'Try something like:';
+    echo '  OPAMCLI=2.0 opam config set-global ANDROID_NDK "/usr/local/lib/android/sdk/ndk/27.1.12297006"';
+    echo '  OPAMCLI=2.0 opam config set-global ANDROID_PLATFORM android-23';
+    exit 108"""
+  ]
+    {(!?ANDROID_NDK | ANDROID_NDK = "") &
+     (dkml-target-abi-android_arm32v7a:installed |
+      dkml-target-abi-android_arm64v8a:installed |
+      dkml-target-abi-android_x86_64:installed)}
+  ["touch" "Brewfile"] {os = "macos"}
+  ["install" "-d" "dl/ocaml/flexdll"]
+  ["tar" "xCfz" "dl/ocaml" "dl/ocaml.tar.gz" "--strip-components=1"]
+  [
+    "tar" "xCfz" "dl/ocaml/flexdll" "dl/flexdll.tar.gz" "--strip-components=1"
+  ]
+  ["install" "debug/env.ml" "debug/persistent_env.ml" "dl/ocaml/typing/"]
+    {dkml-debug-env-failures & version > "4.14.2~v1.2.1~" &
+     version <= "4.14.2"}
+  ["install" "-d" "dkmldir"]
+  [
+    "sh"
+    "-eufc"
+    "printf 'dkml_root_version=%s\\n' '%{version}%' | sed 's/[0-9.]*~v//; s/~/-/' > dkmldir/.dkmlroot"
+  ]
+  ["install" "-d" "dkmldir/vendor/drc"]
+  [
+    "sh"
+    "-eufc"
+    "tar cCf '%{dkml-runtime-common:lib}%/' - . | tar xCf dkmldir/vendor/drc/ -"
+  ]
+  [
+    "install"
+    "-d"
+    "dkmldir/vendor/dkml-compiler/src"
+    "dkmldir/vendor/dkml-compiler/env"
+  ]
+  [
+    "install"
+    "env/standard-compiler-env-to-ocaml-configure-env.sh"
+    "dkmldir/vendor/dkml-compiler/env/"
+  ]
+  [
+    "install"
+    "env/android-ndk-env-to-ocaml-configure-env.sh"
+    "dkmldir/vendor/dkml-compiler/env/"
+  ]
+  [
+    "sh"
+    "-eufc"
+    """
+    sed 's/^INJECT_CFLAGS=$/INJECT_CFLAGS=-Z7/; s/^DEFAULT_AS=$/DEFAULT_AS=ml/; s/^INJECT_ASFLAGS=$/INJECT_ASFLAGS="-Zd -Zi"/' env/standard-compiler-env-to-ocaml-configure-env.sh > dkmldir/vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh
+    """
+  ] {dkml-option-debuginfo:installed & dkml-host-abi-windows_x86:installed}
+  [
+    "sh"
+    "-eufc"
+    """
+    sed 's/^INJECT_CFLAGS=$/INJECT_CFLAGS=-Z7/; s/^DEFAULT_AS=$/DEFAULT_AS=ml64/; s/^INJECT_ASFLAGS=$/INJECT_ASFLAGS="-Zd -Zi"/' env/standard-compiler-env-to-ocaml-configure-env.sh > dkmldir/vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh
+    """
+  ]
+    {dkml-option-debuginfo:installed & dkml-host-abi-windows_x86_64:installed}
+  [
+    "sh"
+    "-eufc"
+    """
+    sed 's/^INJECT_CFLAGS=$/INJECT_CFLAGS=-Z7/; s/^DEFAULT_AS=$/DEFAULT_AS=armasm64/; s/^INJECT_ASFLAGS=$/INJECT_ASFLAGS="-Zd -Zi"/' env/standard-compiler-env-to-ocaml-configure-env.sh > dkmldir/vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh
+    """
+  ] {dkml-option-debuginfo:installed & dkml-host-abi-windows_arm64:installed}
+  [
+    "sh"
+    "-eufc"
+    """
+    sed 's/^INJECT_CFLAGS=$/INJECT_CFLAGS="-g -O0"/; s/^INJECT_ASFLAGS=$/INJECT_ASFLAGS="-g -O0"/' env/standard-compiler-env-to-ocaml-configure-env.sh > dkmldir/vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh
+    """
+  ] {dkml-option-debuginfo:installed & os = "linux"}
+  [
+    "sh"
+    "-eufc"
+    "sed 's/^INJECT_CFLAGS=$/INJECT_CFLAGS=-Os/ env/standard-compiler-env-to-ocaml-configure-env.sh > dkmldir/vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh"
+  ] {dkml-option-minsize:installed & os = "linux"}
+  [
+    "sh"
+    "-eufc"
+    "tar cCf src/ - . | tar xCf dkmldir/vendor/dkml-compiler/src/ -"
+  ]
+  ["sh" "scripts/install-ocamlc-opt.sh" "windows_x86" ".exe"]
+    {dkml-host-abi-windows_x86:installed}
+  ["sh" "scripts/install-ocamlc-opt.sh" "windows_x86_64" ".exe"]
+    {dkml-host-abi-windows_x86_64:installed}
+  ["sh" "scripts/install-ocamlc-opt.sh" "windows_arm64" ".exe"]
+    {dkml-host-abi-windows_arm64:installed}
+  ["sh" "scripts/install-ocamlc-opt.sh" "linux_x86" ""]
+    {dkml-host-abi-linux_x86:installed}
+  ["sh" "scripts/install-ocamlc-opt.sh" "linux_x86_64" ""]
+    {dkml-host-abi-linux_x86_64:installed}
+  ["sh" "scripts/install-ocamlc-opt.sh" "darwin_x86_64" ""]
+    {dkml-host-abi-darwin_x86_64:installed}
+  ["sh" "scripts/install-ocamlc-opt.sh" "darwin_arm64" ""]
+    {dkml-host-abi-darwin_arm64:installed}
+]
+install: [
+  [
+    "env"
+    "DKML_REPRODUCIBLE_SYSTEM_BREWFILE=%{_:build}%/Brewfile"
+    "bash"
+    "dkmldir/vendor/dkml-compiler/src/r-c-ocaml-1-setup.sh"
+    "-d"
+    "dkmldir"
+    "-t"
+    "%{prefix}%"
+    "-f"
+    "src-ocaml"
+    "-g"
+    "%{_:share}%/mlcross"
+    "-v"
+    "dl/ocaml"
+    "-c"
+    "vendor/dkml-compiler/bin/bootstrap-ocamlc.opt.exe"
+    "-z"
+    "-l" {os = "win32" & dkml-option-debuginfo:installed}
+    " -link /DEBUG:FULL" {os = "win32" & dkml-option-debuginfo:installed}
+    "-m" {!dkml-option-debuginfo:installed}
+    "--disable-debug-runtime --disable-instrumented-runtime"
+      {!dkml-option-debuginfo:installed}
+    "-n" {!dkml-option-debuginfo:installed}
+    "--disable-debug-runtime --disable-instrumented-runtime"
+      {!dkml-option-debuginfo:installed}
+    "-e%{dkml-host-abi:abi}%"
+    "-adarwin_x86_64=vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh"
+      {dkml-host-abi:abi != "darwin_x86_64" &
+       dkml-target-abi-darwin_x86_64:installed}
+    "-adarwin_arm64=vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh"
+      {dkml-host-abi:abi != "darwin_arm64" &
+       dkml-target-abi-darwin_arm64:installed}
+    "-aandroid_arm32v7a=vendor/dkml-compiler/env/android-ndk-env-to-ocaml-configure-env.sh"
+      {dkml-target-abi-android_arm32v7a:installed}
+    "-aandroid_arm64v8a=vendor/dkml-compiler/env/android-ndk-env-to-ocaml-configure-env.sh"
+      {dkml-target-abi-android_arm64v8a:installed}
+    "-aandroid_x86_64=vendor/dkml-compiler/env/android-ndk-env-to-ocaml-configure-env.sh"
+      {dkml-target-abi-android_x86_64:installed}
+    "-k"
+    "vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh"
+  ]
+  [
+    "sh"
+    "scripts/build.sh"
+    "-p"
+    "%{prefix}%"
+    "-s"
+    "r-c-ocaml-2-build_host-noargs.sh"
+  ]
+  [
+    "sh"
+    "scripts/build.sh"
+    "-p"
+    "%{prefix}%"
+    "-s"
+    "r-c-ocaml-3-build_cross-noargs.sh"
+  ]
+]
+build-env: [
+  [ANDROID_PLATFORM = "%{ANDROID_PLATFORM}%"]
+  [ANDROID_NDK = "%{ANDROID_NDK}%"]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-compiler.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-compiler/releases/download/2.1.4-r1/src.tar.gz"
+  checksum: [
+    "md5=09e06c03a8c251bbd7a527d011800431"
+    "sha512=aff4327a330918397449550ec454ccd994be386f624f84e05ef6feab2f1f25df230e10e85a7baef546a42ca7751a1b42a0371c3bc7b992f325755e4c966f1e92"
+  ]
+}
+extra-source "dl/darwin_arm64-ocamlc.opt" {
+  src:
+    "https://github.com/diskuv/dkml-compiler/releases/download/2.1.0-1/darwin_arm64-ocamlc.opt"
+  checksum:
+    "sha256=8cc9568301770454e5f8f81a4279baa48e786e24867cc4aa94c88653f3f93aae"
+}
+extra-source "dl/darwin_x86_64-ocamlc.opt" {
+  src:
+    "https://github.com/diskuv/dkml-compiler/releases/download/2.1.0-1/darwin_x86_64-ocamlc.opt"
+  checksum:
+    "sha256=89971a82713071d8afa3b7570ca62f98ce95ab641d0af3f891554fa4e262b737"
+}
+extra-source "dl/flexdll.tar.gz" {
+  src: "https://github.com/ocaml/flexdll/archive/0.43.tar.gz"
+  checksum:
+    "sha256=10e171ab7d2f8b2f238b53bb9944d4b26686f5703fbc1c059532791bc91be949"
+}
+extra-source "dl/homebrew-bundle.tar.gz" {
+  src:
+    "https://github.com/Homebrew/homebrew-bundle/archive/437c67db2f160369fec3a3892e3c577b6b3a4d2c.tar.gz"
+  checksum:
+    "sha256=ecb6b03b2d0210369f23e3f8f64cd939a4bba633db08db62a49894653e053df4"
+}
+extra-source "dl/linux_x86-ocamlc.opt" {
+  src:
+    "https://github.com/diskuv/dkml-compiler/releases/download/2.1.0-1/linux_x86-ocamlc.opt"
+  checksum:
+    "sha256=3ae5b3fcf1b6f75104adac0365b1d600113bead38ea93e1a673861d48d275dea"
+}
+extra-source "dl/linux_x86_64-ocamlc.opt" {
+  src:
+    "https://github.com/diskuv/dkml-compiler/releases/download/2.1.0-1/linux_x86_64-ocamlc.opt"
+  checksum:
+    "sha256=beb3a45c8bb3899c6d51195db929176481640a33c1ed3f3816fcce657d9690dd"
+}
+extra-source "dl/ocaml.tar.gz" {
+  src: "https://github.com/ocaml/ocaml/archive/4.14.2.tar.gz"
+  checksum:
+    "sha256=c2d706432f93ba85bd3383fa451d74543c32a4e84a1afaf3e8ace18f7f097b43"
+}
+extra-source "dl/windows_x86-ocamlc.opt.exe" {
+  src:
+    "https://github.com/diskuv/dkml-compiler/releases/download/2.1.0-1/windows_x86-ocamlc.opt.exe"
+  checksum:
+    "sha256=ff7c95619120f265c9e2b0d73677fd5411b9b6c05655063caf7d65b33b23f3c7"
+}
+extra-source "dl/windows_x86_64-ocamlc.opt.exe" {
+  src:
+    "https://github.com/diskuv/dkml-compiler/releases/download/2.1.0-1/windows_x86_64-ocamlc.opt.exe"
+  checksum:
+    "sha256=98e1a3df7f9e59cfdbe53c259cb0284b24f393fbc89777ef029d12e33ba417e6"
+}

--- a/packages/dkml-compiler-src/dkml-compiler-src.2.1.4~r1/opam
+++ b/packages/dkml-compiler-src/dkml-compiler-src.2.1.4~r1/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+synopsis: "Source code used to build the DkML compiler"
+maintainer: "opensource+diskuv-ocaml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-compiler"
+bug-reports: "https://github.com/diskuv/dkml-compiler/issues"
+install: [
+  [".\\install-src.cmd" "%{_:lib}%"] {os = "win32"}
+  ["sh" "./install-src.sh" "%{_:lib}%"] {!(os = "win32")}
+]
+dev-repo: "git+https://github.com/diskuv/dkml-compiler.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-compiler/releases/download/2.1.4-r1/src.tar.gz"
+  checksum: [
+    "md5=09e06c03a8c251bbd7a527d011800431"
+    "sha512=aff4327a330918397449550ec454ccd994be386f624f84e05ef6feab2f1f25df230e10e85a7baef546a42ca7751a1b42a0371c3bc7b992f325755e4c966f1e92"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`dkml-base-compiler.2.1.4~r1`: OCaml cross-compiler and libraries from the DkML distribution
-`dkml-compiler-src.2.1.4~r1`: Source code used to build the DkML compiler



---

---
:camel: Pull-request generated by opam-publish v2.1.0